### PR TITLE
Channel access monitors: draft for discussion.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "editor.defaultFormatter": "ms-python.python",
     "python.linting.pylintEnabled": false,
     "python.linting.flake8Enabled": true,
     "python.linting.enabled": true,

--- a/coniql/caplugin.py
+++ b/coniql/caplugin.py
@@ -192,15 +192,16 @@ class CAPlugin(Plugin):
         )
         try:
             first_update = await q.get()
-            yield channel.update_value(**first_update)
             # A specific request required for whether the channel is writeable.
             # This will not be updated, so wait until a callback is received
             # before making the request when the channel is likely be connected.
             try:
                 info = await cainfo(pv)
-                yield channel.update_value(writeable=info.write)
+                first_update["writeable"] = info.write
             except CANothing:
                 pass  # Allow subscriptions to continue
+
+            yield channel.update_value(**first_update)
             # Handle all updates from both monitors.
             while True:
                 update = await q.get()

--- a/coniql/caplugin.py
+++ b/coniql/caplugin.py
@@ -121,11 +121,9 @@ class CAChannel:
             self.writeable = writeable
             if status is not None:
                 status.mutable = writeable
-            elif time_value is not None:
+            elif self.cached_status is not None:
                 status = ChannelStatus(
-                    quality=CHANNEL_QUALITY_MAP[time_value.severity],
-                    message="",
-                    mutable=writeable,
+                    quality=self.cached_status.quality, message="", mutable=writeable,
                 )
                 self.cached_status = status
 

--- a/coniql/caplugin.py
+++ b/coniql/caplugin.py
@@ -1,4 +1,5 @@
 import asyncio
+from dataclasses import dataclass
 from typing import AsyncIterator, List, Optional, Tuple
 
 from aioca import (
@@ -124,12 +125,12 @@ class CAChannel:
         return CAChannelUpdate(value, time, status, display)
 
 
+@dataclass
 class CAChannelUpdate(Channel):
-    def __init__(self, value, time, status, display):
-        self.value = value
-        self.time = time
-        self.status = status
-        self.display = display
+    value: Optional[ChannelValue]
+    time: Optional[ChannelTime]
+    status: Optional[ChannelStatus]
+    display: Optional[ChannelDisplay]
 
     def get_time(self) -> Optional[ChannelTime]:
         return self.time

--- a/tests/test_caplugin.py
+++ b/tests/test_caplugin.py
@@ -184,13 +184,13 @@ subscription {
         results.append(result)
         if time.time() - start > 0.9:
             break
-    for i, x in enumerate(range(3)):
+    for i in range(3):
         display = None
         if i == 0:
             display = dict(precision=5, units="mm")
         assert results[i] == dict(
             data=dict(
-                subscribeChannel=dict(value=dict(string="%.5f mm" % x), display=display)
+                subscribeChannel=dict(value=dict(string="%.5f mm" % i), display=display)
             )
         )
     assert len(results) == 3


### PR DESCRIPTION
See #22.

Plenty to discuss here:

* It seemed easier to use one object than to recreate each time as previously
* We need to distinguish updates from the two monitors as we want to get `value` from the `FORMAT_TIME` monitor. We could
  * Have two queues: probably neatest but we'd need to respond to updates on both promptly.
  * Distinguish by `timestamp` outside of the class (as I have done)
  * Distinguish by `timestamp` inside the class
* Recreating the formatter each update seems somewhat heavyweight, but if `units` or `enums` or `precision` change then we do want to create a new one

Any thoughts?